### PR TITLE
Replace setup.py with a static config (setup.cfg & pyproject.toml)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "TUIFIManager"
+version = "2.1.9"
+
+description = "A cross-platform terminal-based termux-oriented file manager."
+requires-python = ">=3.8"
+readme = "README.md"
+
+dependencies = [
+    "uni-curses >= 2.1.3",
+    "Send2Trash == 1.8.0",
+]
+
+license = {text = "General Public License v3.0"}
+classifiers = [
+    "Environment :: Terminals",
+    "Intended Audience :: Developers",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10"
+]
+
+keywords = [
+    "file-manager",
+    "terminal",
+    "tui",
+    "ncurses",
+    "pdcurses",
+    "uni-curses",
+    "termux",
+    "vim",
+    "vim-motions",
+    "cross-platform"
+]
+
+[project.scripts]
+tuifi = "TUIFIManager.__main__:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 uni-curses >= 2.1.3
+Send2Trash == 1.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,42 @@
+
+[metadata]
+name = TUIFIManager
+version = 2.1.9
+description = A cross-platform terminal-based termux-oriented file manager
+long_description = file: docs/README.md
+long_description_content_type = text/markdown
+author = George Chousos
+author_email = gxousos@gmail.com
+keywords = file-manager, terminal, tui, ncurses, pdcurses, uni-curses, termux, vim, vim-motions, cross-platform
+license = GPL-3.0
+license_file = LICENSE
+platform = unix, linux, osx, cygwin, windows
+url = https://github.com/GiorgosXou/TUIFIManager
+project_urls =
+    Github=https://github.com/GiorgosXou/TUIFIManager
+classifiers =
+    Environment :: Terminals
+    Intended Audience :: Developers
+    Intended Audience :: End Users/Desktop
+    License :: OSI Approved :: MIT License
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+
+
+[options]
+include_package_data = True
+packages =
+    TUIFIManager
+python_requires = >=3.8
+install_requires =
+    Uni-Curses >= 2.1.3
+    Send2Trash == 1.8.0
+
+[options.entry_points]
+console_scripts =
+    tuifi = TUIFIManager.__main__:main

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,4 @@
 from setuptools import setup
-import sys
 
-
-if sys.version_info.major < 3:
-    sys.exit('Python < 3 is unsupported (for now).')
-    
-
-#def readfile(filename):
-#    with open(filename, 'r+') as f:
-#        return f.read()
-
-
-setup(
-    name="TUIFIManager",
-    version="2.1.9",
-    description="A cross-platform terminal-based termux-oriented file manager (and component), meant to be used with a Uni-Curses project or as is. This project is mainly an attempt to get more attention to the Uni-Curses project.",
-    #long_description=readfile('README.md'),
-    author="George Chousos",
-    author_email="gxousos@gmail.com",
-    url="https://github.com/GiorgosXou/TUIFIManager",
-    packages=['TUIFIManager'],
-    install_requires=['Uni-Curses>=2.1.3', 'Send2Trash==1.8.0'],
-    entry_points={
-        'console_scripts': [
-            'tuifi = TUIFIManager.__main__:main'
-        ]
-    },
-)
-
-# pip3 install .
-# python setup.py sdist
-# twine upload dist/*
+if __name__ == '__main__':
+    setup()


### PR DESCRIPTION
Add a `setup.cfg` and a `pyproject.toml` and upate `setup.py` for legacy support

For more details on the files fields:
- [Configuring setuptools using `setup.cfg` files](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) 
- [Configuring setuptools using `pyproject.toml` files](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/)

Also fix missing dep in `requirements.txt` (send2 trash).

Verified on nox by #56 
Closes #44 