### PR TITLE
Allow use of send2trash >= `1.8.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 dependencies = [
     "uni-curses >= 2.1.3",
-    "Send2Trash == 1.8.0",
+    "Send2Trash >= 1.8.0",
 ]
 
 license = {text = "General Public License v3.0"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 uni-curses >= 2.1.3
-Send2Trash == 1.8.0
+Send2Trash >= 1.8.0


### PR DESCRIPTION
In an effort to make packaging easier, allowing use of a more recent version of the `send2trash` would be great.
Currently, this package latest version is `1.8.2`