### PR TITLE
Add nixpkgs major system (compatible)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,12 @@
     nixpkgs,
     flake-utils,
   }:
-    flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ] (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
       devShells.default = let


### PR DESCRIPTION
Tested on `aarch64-darwin` & `aarch64-linux`