### PR TITLE
FIXED: No module names 'pipes' in Python 3.13 #123

### DIFF
--- a/TUIFIManager/TUItilities.py
+++ b/TUIFIManager/TUItilities.py
@@ -7,7 +7,7 @@ import   threading
 from   dataclasses import dataclass
 from       os.path import isfile
 from        shutil import which
-from         pipes import quote
+from         shlex import quote
 from          time import sleep
 from            os import getenv, getcwd
 


### PR DESCRIPTION
Sending a pull request for my proposed solution to the issue.