### PR TITLE
add missing key to pyproject.toml config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "TUIFIManager"
 version = "5.0.7"
 
+authors = [{name="George Chousos", email="gxousos@gmail.com"}]
+
 description = "A cross-platform terminal-based termux-oriented file manager."
 requires-python = ">=3.8"
 readme = "README.md"
@@ -41,6 +43,9 @@ keywords = [
     "vim-motions",
     "cross-platform"
 ]
+
+[project.urls]
+Github="https://github.com/GiorgosXou/TUIFIManager"
 
 [project.scripts]
 tuifi = "TUIFIManager.__main__:main"


### PR DESCRIPTION
While building for nixpkgs, i noticed this 2 warnings poping-up, so i decided to fix them:
```
* Building wheel...
/nix/store/sfifx7g499n2xfvs5hzvw3mxinn0i17x-python3.12-setuptools-75.3.0/lib/python3.12/site-packages/setuptools/config/expand.py:126: SetuptoolsWarning: File '/build/source/docs/README.md' cannot be found
  for path in _filter_existing_files(_filepaths)
/nix/store/sfifx7g499n2xfvs5hzvw3mxinn0i17x-python3.12-setuptools-75.3.0/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:71: _MissingDynamic: `authors` defined outside of `pyproject.toml` is ignored.
!!

        ********************************************************************************
        The following seems to be defined outside of `pyproject.toml`:

        `authors = 'George Chousos'`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `authors` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table

        To prevent this problem, you can list `authors` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.
        ********************************************************************************

!!
  _handle_missing_dynamic(dist, project_table)
/nix/store/sfifx7g499n2xfvs5hzvw3mxinn0i17x-python3.12-setuptools-75.3.0/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:71: _MissingDynamic: `urls` defined outside of `pyproject.toml` is ignored.
!!

        ********************************************************************************
        The following seems to be defined outside of `pyproject.toml`:

        `urls = {'Github': 'https://github.com/GiorgosXou/TUIFIManager'}`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `urls` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table

        To prevent this problem, you can list `urls` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.
        ********************************************************************************

!!
  _handle_missing_dynamic(dist, project_table)
/nix/store/sfifx7g499n2xfvs5hzvw3mxinn0i17x-python3.12-setuptools-75.3.0/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:78: SetuptoolsWarning: `install_requires` overwritten in `pyproject.toml` (dependencies)
  corresp(dist, value, root_dir)
running bdist_wheel
```